### PR TITLE
Fix build errors with GCC 13

### DIFF
--- a/FPGA-gpiRead/hps.h
+++ b/FPGA-gpiRead/hps.h
@@ -70,7 +70,7 @@ extern "C"
     // macro to include the virtual Memory 
     //
     //
-#define __VIRTUALMEM_SPACE_INIT()                                                                                          \                                                                                                              \
+#define __VIRTUALMEM_SPACE_INIT()                                                                                          \
         __fd = open("/dev/mem", (O_RDWR | O_SYNC));                                                                              \
 	__hps_virtualAdreess_FPGAMFRDATA  = mmap(NULL, 0x04,(PROT_READ | PROT_WRITE), MAP_SHARED, __fd, ALT_FPGAMGRDATA_OFST);      \
 	__hps_virtualAdreess_FPGAMGR = mmap(NULL, 0x1000,(PROT_READ | PROT_WRITE), MAP_SHARED, __fd, ALT_FPGAMGR_OFST)             

--- a/FPGA-readMSEL/hps.h
+++ b/FPGA-readMSEL/hps.h
@@ -70,7 +70,7 @@ extern "C"
     // macro to include the virtual Memory 
     //
     //
-    #define __VIRTUALMEM_SPACE_INIT()                                                                                          \                                                                                                          \
+    #define __VIRTUALMEM_SPACE_INIT()                                                                                          \
         __fd = open("/dev/mem", (O_RDWR | O_SYNC));                                                                              \
 	    __hps_virtualAdreess_FPGAMFRDATA  = mmap(NULL, 0x04,(PROT_READ | PROT_WRITE), MAP_SHARED, __fd, ALT_FPGAMGRDATA_OFST);      \
 	    __hps_virtualAdreess_FPGAMGR = mmap(NULL, 0x1000,(PROT_READ | PROT_WRITE), MAP_SHARED, __fd, ALT_FPGAMGR_OFST)             

--- a/FPGA-status/hps.h
+++ b/FPGA-status/hps.h
@@ -70,7 +70,7 @@ extern "C"
     // macro to include the virtual Memory 
     //
     //
-    #define __VIRTUALMEM_SPACE_INIT()                                                                                          \                                                                                       \
+    #define __VIRTUALMEM_SPACE_INIT()                                                                                          \
      __fd = open("/dev/mem", (O_RDWR | O_SYNC));                                                                              \
 	__hps_virtualAdreess_FPGAMFRDATA  = mmap(NULL, 0x04,(PROT_READ | PROT_WRITE), MAP_SHARED, __fd, ALT_FPGAMGRDATA_OFST);      \
 	__hps_virtualAdreess_FPGAMGR = mmap(NULL, 0x1000,(PROT_READ | PROT_WRITE), MAP_SHARED, __fd, ALT_FPGAMGR_OFST)             

--- a/FPGA-writeBridge/main.cpp
+++ b/FPGA-writeBridge/main.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <unistd.h>
 #include <sstream>
+#include <cstdint>
 using namespace std;
 
 #define DEC_INPUT 1

--- a/FPGA-writeConfig/hps.h
+++ b/FPGA-writeConfig/hps.h
@@ -70,8 +70,8 @@ extern "C"
     // macro to include the virtual Memory 
     //
     //
-    #define __VIRTUALMEM_SPACE_INIT()                                                                                          \                                                                                                            \
-            fd = open("/dev/mem", (O_RDWR | O_SYNC));                                                                              \
+    #define __VIRTUALMEM_SPACE_INIT()                                                                                          \
+            __fd = open("/dev/mem", (O_RDWR | O_SYNC));                                                                              \
 	    __hps_virtualAdreess_FPGAMFRDATA  = mmap(NULL, 0x04,(PROT_READ | PROT_WRITE), MAP_SHARED, __fd, ALT_FPGAMGRDATA_OFST);      \
 	    __hps_virtualAdreess_FPGAMGR = mmap(NULL, 0x1000,(PROT_READ | PROT_WRITE), MAP_SHARED, __fd, ALT_FPGAMGR_OFST)             
 


### PR DESCRIPTION
Hi,

Building rstools with GCC 13 leads to some fatal errors. I estimate these used to be warning. Most changes are trivial, duplicate `\` and missing include header for integer type. The change in `FPGA-writeConfig/hps.h` was definitely surprising. I do not understand how this used to work.

I hope this patch is useful to you.